### PR TITLE
encrypt password/api-tokens

### DIFF
--- a/updater.sh
+++ b/updater.sh
@@ -33,10 +33,12 @@ if ! hash curl 2>/dev/null; then
 	exit 1
 fi
 
+# if this fails with error 60 your certificate store does not contain the certificate,
+# either add it or use -k (disable certificate check
 ret=`curl --basic \
 	-u "$YDNS_USER:$YDNS_PASSWD" \
 	--silent \
-	http://ydns.eu/api/v1/update/?host=$YDNS_HOST`
+	https://ydns.eu/api/v1/update/?host=$YDNS_HOST`
 
 if [ "$ret" = "ok" ]; then
 	echo "Update: OK"


### PR DESCRIPTION
With only http the credentials (esp password/api token) are sent in plain text.

This changes communication to encrypted.
