### PR TITLE
updater.sh: fix shebang line

### DIFF
--- a/updater.sh
+++ b/updater.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # yDNS Updater, updates your yDNS host.
 # Copyright (C) 2013 Christian Jurk <cj@ydns.eu>


### PR DESCRIPTION
Using `/usr/bin/env bash` instead of `/bin/bash` is more portable and
also works if user has their own bash outside of `/bin`.

For example many people installed bash from homebrew on OS X while Apple
was taking a long time to fix shellshock.