### PR TITLE
Contribution to your updater script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,11 @@ The code is licensed under the GNU Public License, version 3.
 ## Contribution
 
 If you like to contribute useful changes to the script, simply fork the project, apply your changes and make a pull request.
+
+## Changes on this fork
+
+Support for IPv6 AAAA Records
+Support for IPv4 A Records
+Support for multiple hosts
+Filter for the default route interface if none has been specified.
+Filter for API return messages.

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ If you like to contribute useful changes to the script, simply fork the project,
 
 ## Changes on this fork
 
-Support for IPv6 AAAA Records
-Support for IPv4 A Records
-Support for multiple hosts
-Filter for the default route interface if none has been specified.
-Filter for API return messages.
+- Support for IPv6 AAAA Records
+- Support for IPv4 A Records
+- Support for multiple hosts
+- Filter for the default route interface if none has been specified.
+- Filter for API return messages.


### PR DESCRIPTION
I remarked that the script which has been updated 8 years ago does no longer work.
Therefore I did some changes.
These are:
- Support for ipv6 AAAA records.
- Support for ipv4 A records remains the same.
- Support for multiple host entries separated by space remains.
- Detect interface of the default route in case that non has been provided.
- The temp file (per host) now holds both records (ipv4 on fist line, ipv6 on second line.
- I have tested the changes on openwrt.